### PR TITLE
Explicitly specify Linux dist to be Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 matrix:
   include:
   - os: linux
+    dist: trusty
     jdk: oraclejdk8
   - os: osx
     osx_image: xcode8


### PR DESCRIPTION
Stopgap fix to allow Travis CI to work for the Linux jobs. See the
[Travis blog](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) for details