### PR TITLE
Consolidate the versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.2.2</spark.version>
     </properties>
     <dependencies>
         <dependency>
@@ -33,12 +34,12 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
-            <version>2.2.2</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.11</artifactId>
-            <version>2.2.1</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scalactic</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,13 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
             <version>${spark.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.11</artifactId>
             <version>${spark.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scalactic</groupId>


### PR DESCRIPTION
Generally, it is a bad practice to use different versions of Spark together, therefore I'd suggest to set it to 2.2.2 for now using a Maven property.