### PR TITLE
Make Spark dependency provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,13 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
             <version>2.2.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.11</artifactId>
             <version>2.2.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scalactic</groupId>


### PR DESCRIPTION
Currently, we're using the `spark-sqldb-spark` package with Spark 2.4. This works, but for the packaging, we have to exclude the Spark dependency from `azure-sql-db`. Generally, it is recommended to mark Spark provided when it comes to a plugin, so it can be used with different Spark versions as well. For example, they mark them as provided at CosmosDB as well: https://github.com/Azure/azure-cosmosdb-spark/blob/2.4/pom.xml#L51-L56